### PR TITLE
refactor: async service lifecycle and startup

### DIFF
--- a/src/main/classes/core/ServiceManager.ts
+++ b/src/main/classes/core/ServiceManager.ts
@@ -88,7 +88,7 @@ export default class ServiceManager extends SelfManagedSingleton {
   /**
    * Initializes all registered services.
    */
-  public init(): void {
+  public async init(): Promise<void> {
     if (this._ready) {
       this.logger.warn("Service Manager has already been initialized");
       return;
@@ -96,11 +96,10 @@ export default class ServiceManager extends SelfManagedSingleton {
 
     for (const [key, service] of this.registry.entries()) {
       try {
-        service.init?.();
+        await service.init?.();
+        this.logger.info(`Service '${key}' initialized successfully`);
       } catch (err) {
         this.logger.error(`Error initializing ${key}: ${err}`);
-      } finally {
-        this.logger.info(`Service '${key}' initialized successfully`);
       }
     }
 
@@ -111,17 +110,16 @@ export default class ServiceManager extends SelfManagedSingleton {
    * Disposes all registered services.
    * This is the final step in the service lifecycle.
    */
-  public dispose(): void {
+  public async dispose(): Promise<void> {
     // Dispose services in reverse order
     const services = Array.from(this.registry.entries()).reverse();
 
     for (const [key, service] of services) {
       try {
-        service.dispose?.();
+        await service.dispose?.();
+        this.logger.info(`${key} disposed successfully`);
       } catch (error) {
         this.logger.error(`Failed to dispose service: ${key}`);
-      } finally {
-        this.logger.info(`${key} disposed successfully`);
       }
     }
 

--- a/src/main/classes/helpers/Asset.ts
+++ b/src/main/classes/helpers/Asset.ts
@@ -44,7 +44,7 @@ export default class Asset {
    * @param relPath - Should be relative to the asset directory.
    */
   public static formPath(relPath: string) {
-    const basePath = swallow(app.getAppPath, process.cwd());
+    const basePath = swallow(() => app.getAppPath(), process.cwd());
 
     return join(basePath, Asset.defaultDir, relPath);
   }

--- a/src/main/classes/services/Logger.ts
+++ b/src/main/classes/services/Logger.ts
@@ -1,4 +1,3 @@
-import swallow from "../../functions/swallow";
 import { type Service } from "../core/ServiceManager";
 import debug from "../../constants/debug";
 
@@ -121,7 +120,7 @@ export default class Logger implements Service {
    */
   private route(level: LogLevel, message: string, ctx?: Context) {
     // Return if not in debug & log is debug
-    if (level === LogLevel.DEBUG && !debug) return;
+    if (level === LogLevel.DEBUG && !this.isDebug) return;
 
     const rec = this.format(level, message, ctx);
     this.emit(rec);

--- a/src/main/preload/index.ts
+++ b/src/main/preload/index.ts
@@ -1,1 +1,4 @@
-//todo
+import { contextBridge } from "electron";
+
+// Expose a minimal API to the renderer process. Extend as needed.
+contextBridge.exposeInMainWorld("api", {} as const);


### PR DESCRIPTION
## Summary
- await service initialization and disposal in ServiceManager
- handle async errors when starting and shutting down the app
- expose placeholder API in preload script
- chain app readiness with `electronApp.whenReady().then().catch`

## Testing
- `npx tsc --noEmit`
- `npx tsc -p src/render/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a67ee5b73c832b81f93ba03e4b4384